### PR TITLE
Correctly parse HOST:CONTAINER mapped ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ web:
 database:
   image: postgres
   ports:
-    - "5432"
+    - "5432:5432"
 cache:
   image: memcached
   ports:

--- a/main.go
+++ b/main.go
@@ -22,9 +22,11 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/docker/libcompose/project"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
 var (
@@ -54,7 +56,7 @@ func main() {
 
 	for name, service := range p.Configs {
 		rc := &api.ReplicationController{
-			TypeMeta: api.TypeMeta{
+			TypeMeta: unversioned.TypeMeta{
 				Kind:       "ReplicationController",
 				APIVersion: "v1",
 			},
@@ -84,6 +86,11 @@ func main() {
 		// Configure the container ports.
 		var ports []api.ContainerPort
 		for _, port := range service.Ports {
+			// Check if we have to deal with a mapped port
+			if strings.Contains(port, ":") {
+				parts := strings.Split(port, ":")
+				port = parts[1]
+			}
 			portNumber, err := strconv.Atoi(port)
 			if err != nil {
 				log.Fatalf("Invalid container port %s for service %s", port, name)


### PR DESCRIPTION
Fixes #10.

Also pull in a breaking change from upstream Kubernetes API.
