### PR TITLE
reflect libcompose project change in type Context struct

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	p := project.NewProject(&project.Context{
 		ProjectName: "kube",
-		ComposeFile: composeFile,
+		ComposeFiles: []string{composeFile},
 	})
 
 	if err := p.Parse(); err != nil {


### PR DESCRIPTION
Could build and run compose2kube after this change with dependency https://github.com/docker/libcompose/blob/master/project/context.go in version 0.2.0-dev. 
(version 0.1.0 also has type Context struct with field ComposeFiles []string) 
