### PR TITLE
Namespace and Host Affinity

### DIFF
--- a/createReplicationController.go
+++ b/createReplicationController.go
@@ -86,6 +86,7 @@ func configurePorts(name string, service *config.ServiceConfig) []api.ContainerP
 func configureVariables(service *config.ServiceConfig) []api.EnvVar {
 	// Configure the container ENV variables
 	var envs []api.EnvVar
+	envs = append(envs, api.EnvVar{Name: "NAMESPACE", Value: calculateNamespace()})
 	for _, env := range service.Environment {
 		if strings.Contains(env, "=") {
 			parts := strings.Split(env, "=")

--- a/createReplicationController.go
+++ b/createReplicationController.go
@@ -48,7 +48,8 @@ func createReplicationController(name string, shortName string, service *config.
 						{
 							Name:           shortName,
 							Image:          service.Image,
-							Command:        service.Command,
+							Args:           service.Command,
+							Command:				service.Entrypoint,
 							Ports:          configurePorts(name, service),
 							Env:            configureVariables(service),
 							ReadinessProbe: configureHealthCheck(name, rancherCompose),

--- a/createReplicationController.go
+++ b/createReplicationController.go
@@ -32,7 +32,7 @@ func createReplicationController(name string, shortName string, service *config.
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      shortName,
-			Namespace: "${NAMESPACE}",
+			Namespace: calculateNamespace(),
 			Labels:    configureLabels(shortName, service),
 		},
 		Spec: api.ReplicationControllerSpec{

--- a/createReplicationController.go
+++ b/createReplicationController.go
@@ -33,14 +33,14 @@ func createReplicationController(name string, shortName string, service *config.
 		ObjectMeta: api.ObjectMeta{
 			Name:      shortName,
 			Namespace: calculateNamespace(),
-			Labels:    configureLabels(shortName, service),
+			Labels:    map[string]string{"service": shortName},
 		},
 		Spec: api.ReplicationControllerSpec{
 			Replicas: configureScale(name, rancherCompose),
 			Selector: map[string]string{"service": shortName},
 			Template: &api.PodTemplateSpec{
 				ObjectMeta: api.ObjectMeta{
-					Labels: map[string]string{"service": shortName},
+					Labels: configureLabels(shortName, service),
 				},
 				Spec: api.PodSpec{
 					NodeSelector: configureAffinity(shortName, service), //map[string]string{"cloud.google.com/gke-local-ssd": "true"},
@@ -49,7 +49,7 @@ func createReplicationController(name string, shortName string, service *config.
 							Name:           shortName,
 							Image:          service.Image,
 							Args:           service.Command,
-							Command:				service.Entrypoint,
+							Command:        service.Entrypoint,
 							Ports:          configurePorts(name, service),
 							Env:            configureVariables(service),
 							ReadinessProbe: configureHealthCheck(name, rancherCompose),

--- a/createReplicationController.go
+++ b/createReplicationController.go
@@ -89,7 +89,14 @@ func configureVariables(service *config.ServiceConfig) []api.EnvVar {
 		if strings.Contains(env, "=") {
 			parts := strings.Split(env, "=")
 			ename := parts[0]
-			evalue := "\r" + parts[1]
+			var evalue string
+			if asJSON == true {
+				evalue = parts[1]
+			} else {
+				// I do this in orer to force the yml marshaller to put quotes in all variables
+				// It will be removed later when writing file
+				evalue = "\rYMLMARSHALBUG" + parts[1]
+			}
 			envs = append(envs, api.EnvVar{Name: ename, Value: evalue})
 		}
 	}

--- a/createService.go
+++ b/createService.go
@@ -33,7 +33,7 @@ func createService(shortName string, service *config.ServiceConfig, rc *api.Repl
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      shortName,
-			Namespace: "default",
+			Namespace: calculateNamespace(),
 		},
 		Spec: api.ServiceSpec{
 			Selector: map[string]string{"service": shortName},

--- a/main.go
+++ b/main.go
@@ -19,12 +19,14 @@ var (
 	composeFilePath string
 	outputDir       string
 	asJSON          bool
+	namespace       string
 )
 
 func init() {
 	flag.StringVar(&composeFilePath, "compose-file-path", "./", "Specify an alternate path for compose files")
 	flag.StringVar(&outputDir, "output-dir", "output", "Kubernetes configs output `directory`")
-	flag.BoolVar(&asJSON, "json", false, "output json instead of yaml")
+	flag.BoolVar(&asJSON, "json", false, "Output json instead of yaml")
+	flag.StringVar(&namespace, "namespace", "default", "Default namespace. Use 'ask' for add a question in rancher-compose.yml")
 }
 
 func main() {

--- a/processDockerCompose.go
+++ b/processDockerCompose.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project"
@@ -71,11 +72,13 @@ func writeFile(shortName string, sufix string, object interface{}) {
 		if err != nil {
 			log.Fatalf("Failed to marshal file %s-%s: %v", shortName, sufix, err)
 		}
+		// Remove mark for the right yaml marshal of variables
+		fixedData := strings.Replace(string(data), "\\rYMLMARSHALBUG", "", -1)
 		// Save the replication controller for the Docker compose service to the
 		// configs directory.
 		outputFileName := fmt.Sprintf("%s-%s.yml", shortName, sufix)
 		outputFilePath := filepath.Join(outputDir, outputFileName)
-		if err := ioutil.WriteFile(outputFilePath, data, 0644); err != nil {
+		if err := ioutil.WriteFile(outputFilePath, []byte(fixedData), 0644); err != nil {
 			log.Fatalf("Failed to write service %s: %v", outputFileName, err)
 		}
 		fmt.Println(outputFilePath)

--- a/processDockerCompose.go
+++ b/processDockerCompose.go
@@ -74,6 +74,8 @@ func writeFile(shortName string, sufix string, object interface{}) {
 		}
 		// Remove mark for the right yaml marshal of variables
 		fixedData := strings.Replace(string(data), "\\rYMLMARSHALBUG", "", -1)
+		// Comment ExternalName in order to be compatible with Rancher
+		fixedData = strings.Replace(fixedData, "ExternalName:", "# ExternalName:", -1)
 		// Save the replication controller for the Docker compose service to the
 		// configs directory.
 		outputFileName := fmt.Sprintf("%s-%s.yml", shortName, sufix)


### PR DESCRIPTION
Add the following features:
- Configurable namespace: Use "default" namespace for Replication Controllers (fix) and Services. In addition, you can override the namespace using "-namespace" command line option. There is also a special namespace value "ASK" that causes to put a namespace question in the output rancher-compose.yml so namespace can be chosen when launch from rancher catalog.
- Host affinity support. Convert the label "io.rancher.scheduler.affinity:host_label" to the equivalent affinity syntax for kubernetes. Ignore other rancher cattle labels.
