### PR TITLE
Not assuming docker-compose.yml file name

### DIFF
--- a/processDockerCompose.go
+++ b/processDockerCompose.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project"
@@ -28,6 +29,9 @@ import (
 
 func parseDockerCompose() *project.Project {
 	composeFile := composeFilePath + "docker-compose.yml"
+	if strings.HasSuffix(composeFilePath, ".yml") {
+		composeFile = composeFilePath
+	}
 	p := project.NewProject(&project.Context{
 		ProjectName:  "kube",
 		ComposeFiles: []string{composeFile},


### PR DESCRIPTION
When flag `-compose-file-path` is specified, actually it assumes that it is only the directory name containing `docker-compose.yml` file. This PR adds the behaviour that other file name can be used instead of default `docker-compose.yml` i.e. `-compose-file-path my_directory/my_compose_file_name.yml`.