### PR TITLE
Prevent errors when converting volumes starting ./

### DIFF
--- a/createReplicationController.go
+++ b/createReplicationController.go
@@ -129,6 +129,7 @@ func configureVolumes(service *config.ServiceConfig) ([]api.VolumeMount, []api.V
 				}
 			}
 			partName := strings.Replace(partHostDir, "/", "", -1)
+			partName = strings.TrimPrefix(partName, ".")
 			if len(parts) > 2 {
 				volumemounts = append(volumemounts, api.VolumeMount{Name: partName, ReadOnly: partReadOnly, MountPath: partContainerDir})
 			} else {


### PR DESCRIPTION
If we have a volume defined like this in our docker-compose,

    volumes:
      - ./cache:/var/cache/nginx

The name .cache is generated for the volume which failes the k8s
name specification.

    Error from server: error when creating "output/nginx-rc.yml":
    ReplicationController "nginx" is invalid:
    [spec.template.spec.volumes[0].name: Invalid value: ".cache": must match
    the regex [a-z0-9]([-a-z0-9]*[a-z0-9])? (e.g. 'my-name' or '123-abc'),
    spec.template.spec.containers[0].volumeMounts[0].name: Not found:
    ".cache"]